### PR TITLE
Make redundant-seek use longer timeouts.

### DIFF
--- a/media-source/mediasource-redundant-seek.html
+++ b/media-source/mediasource-redundant-seek.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>Test MediaSource behavior when receiving multiple seek requests during a pending seek.</title>
+        <meta name="timeout" content="long">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="mediasource-util.js"></script>


### PR DESCRIPTION

I did a push with some logging. It looks like this test is currently just on
the border of the 10 second timeout, and sometimes gets killed by the timeout
mechanism before it can finish. Bumping up to 60.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1126465