### PR TITLE
Tag master with the PR id that merged at that point.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ matrix:
   include:
     - os: linux
       python: "2.7"
-      env: JOB=manifest_upload SCRIPT=tools/ci/ci_manifest.sh
+      env:
+        - JOB=manifest_upload SCRIPT=tools/ci/ci_manifest.sh
+        - secure: "FrlMkMZiwggnhJbLiLxZ4imtXxuzFNozty94g1mneMPEVLrnyhb6c/g2SwN37KKU0WSDlGTz26IYnFvo1ftfSOx+sjRz0HqwW7JnrXULKYo7jiPttIcmeJxlSVeW9yS4blbLaBakytHjSnsf+za7bAaf1aS7RRAtAINgifA6Chg="
       deploy:
         provider: releases
         api_key:

--- a/tools/ci/tag_master.py
+++ b/tools/ci/tag_master.py
@@ -50,8 +50,13 @@ def get_pr(repo, owner, rev):
 def tag(repo, owner, sha, tag):
     data = json.dumps({"refs": "refs/tags/%s" % tag,
                        "sha": sha})
-    resp = urllib2.urlopen("https://api.github.com/repos/%s/%s/git/refs" % (repo, owner),
-                           data=data)
+    try:
+        resp = urllib2.urlopen("https://%s@api.github.com/repos/%s/%s/git/refs" %
+                               (os.environ["GH_TOKEN"],repo, owner),
+                               data=data)
+    except Exception as e:
+        logger.error("Tag creation failed:\n%s" % e)
+        return
 
     if resp.code != 201:
         logger.error("Got HTTP status %s" % resp.code)
@@ -62,10 +67,7 @@ def tag(repo, owner, sha, tag):
 def main():
     owner, repo = os.environ["TRAVIS_REPO_SLUG"].split("/", 1)
     if os.environ["TRAVIS_PULL_REQUEST"] != "false":
-        logger.info("Not tagging master for PR")
-        return
-    if os.environ["TRAVIS_PULL_REQUEST"] != "false":
-        logger.info("Not tagging master for PR")
+        logger.info("Not tagging for PR")
         return
     if os.environ["TRAVIS_BRANCH"] != "master":
         logger.info("Not tagging for non-master branch")


### PR DESCRIPTION
For the manifest download stuff we have to have tags per PR merge on
master anyway, and this seems like rather useful information.