### PR TITLE
[Gecko bug 1106913] Bug 1106913 - Detect cyclic objects when marshaling objects. r=whimboo

### DIFF
--- a/webdriver/tests/execute_script/cyclic.py
+++ b/webdriver/tests/execute_script/cyclic.py
@@ -1,0 +1,48 @@
+from tests.support.asserts import assert_error
+
+
+def execute_script(session, script, args=None):
+    if args is None:
+        args = []
+    body = {"script": script, "args": args}
+    return session.transport.send(
+        "POST",
+        "/session/{session_id}/execute/sync".format(
+            session_id=session.session_id),
+        body)
+
+
+def test_array(session):
+    response = execute_script(session, """
+        let arr = [];
+        arr.push(arr);
+        return arr;
+        """)
+    assert_error(response, "javascript error")
+
+
+def test_object(session):
+    response = execute_script(session, """
+        let obj = {};
+        obj.reference = obj;
+        return obj;
+        """)
+    assert_error(response, "javascript error")
+
+
+def test_array_in_object(session):
+    response = execute_script(session, """
+        let arr = [];
+        arr.push(arr);
+        return {arr};
+        """)
+    assert_error(response, "javascript error")
+
+
+def test_object_in_array(session):
+    response = execute_script(session, """
+        let obj = {};
+        obj.reference = obj;
+        return [obj];
+        """)
+    assert_error(response, "javascript error")


### PR DESCRIPTION
Marionette does currently not test for cyclic object references as
it marshals return values for transport across the wire.

Example of cyclic object:

	let obj = {};
	obj.cyclic = obj;

Passing this through evalaute.toJSON currently causes an infinite
recursion due to obj being referenced inside itself.  We can use
JSON.stringify to test if obj contains such cyclic values.  It is
assumed that the input to assert.acyclic is already JSON safe, so it can
be parsed by JSON.stringify, because of the previous checks it has made.

MozReview-Commit-ID: 4CnY2dcW5IF