### PR TITLE
[Gecko Bug 1422839]  Add internal overflow-clip-box-block/-inline properties and make overflow-clip-box a shorthand.  r=dholbert

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1054,12 +1054,6 @@ const gCSSProperties = {
     types: [
     ]
   },
-  'overflow-clip-box': {
-    // https://developer.mozilla.org/en/docs/Web/CSS/overflow-clip-box
-    types: [
-      { type: 'discrete', options: [ [ 'padding-box', 'content-box' ] ] }
-    ]
-  },
   'overflow-wrap': {
     // https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
     types: [


### PR DESCRIPTION
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=Bug 1422839
gecko-commit: 436d102343668d07c92e4be00e90d2d31f89c599
gecko-integration-branch: mozilla-inbound
gecko-reviewers: dholbert