### PR TITLE
[Gecko Bug 1422839]  Add internal overflow-clip-box-block/-inline properties and make overflow-clip-box a shorthand.  r=dholbert

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1054,12 +1054,6 @@ const gCSSProperties = {
     types: [
     ]
   },
-  'overflow-clip-box': {
-    // https://developer.mozilla.org/en/docs/Web/CSS/overflow-clip-box
-    types: [
-      { type: 'discrete', options: [ [ 'padding-box', 'content-box' ] ] }
-    ]
-  },
   'overflow-wrap': {
     // https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
     types: [


### PR DESCRIPTION
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=Bug 1422839
gecko-commit: cf93ccd03ca7d452aa1e1e9bff575f0992df7874
gecko-integration-branch: autoland
gecko-reviewers: dholbert