### PR TITLE
[Gecko Bug 1106913]  Detect cyclic objects when marshaling objects. r=whimboo

### DIFF
--- a/service-workers/service-worker/resources/about-blank-replacement-popup-frame.py
+++ b/service-workers/service-worker/resources/about-blank-replacement-popup-frame.py
@@ -12,11 +12,14 @@ def main(request, response):
 <script>
 function nestedLoaded() {
   parent.postMessage({ type: 'NESTED_LOADED' }, '*');
-  popup.close();
 }
 
 let popup = window.open('?nested=true');
 popup.onload = nestedLoaded;
+
+addEventListener('unload', evt => {
+  popup.close();
+}, { once: true });
 
 // Helper routine to make it slightly easier for our parent to find
 // the nested popup window.

--- a/wasm/wasm_local_iframe_test.html
+++ b/wasm/wasm_local_iframe_test.html
@@ -2,16 +2,18 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/load_wasm.js"></script>
-<iframe src="resources/frame.html" id="iframe"></iframe>
 <script>
-  promise_test(async function() {
-    var mod = await createWasmModule();
-    assert_true(mod instanceof WebAssembly.Module);
-    var ans = await new Promise((resolve, reject) => {
-      var iframe = document.getElementById("iframe").contentWindow;
-      iframe.postMessage(mod, '*');
-      window.addEventListener("message", (reply) => resolve(reply.data), false);
-    });
-    assert_equals(ans, 43);
-  }, "send wasm module to iframe");
+  function runTests(iframe) {
+      iframe = iframe.contentWindow;
+      promise_test(async function() {
+        var mod = await createWasmModule();
+        assert_true(mod instanceof WebAssembly.Module);
+        var ans = await new Promise((resolve, reject) => {
+          iframe.postMessage(mod, '*');
+          window.addEventListener("message", (reply) => resolve(reply.data), false);
+        });
+        assert_equals(ans, 43);
+      }, "send wasm module to iframe");
+  }
 </script>
+<iframe src="resources/frame.html" onload="runTests(this)"></iframe>

--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1054,12 +1054,6 @@ const gCSSProperties = {
     types: [
     ]
   },
-  'overflow-clip-box': {
-    // https://developer.mozilla.org/en/docs/Web/CSS/overflow-clip-box
-    types: [
-      { type: 'discrete', options: [ [ 'padding-box', 'content-box' ] ] }
-    ]
-  },
   'overflow-wrap': {
     // https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
     types: [

--- a/webdriver/tests/execute_script/cyclic.py
+++ b/webdriver/tests/execute_script/cyclic.py
@@ -1,0 +1,48 @@
+from tests.support.asserts import assert_error
+
+
+def execute_script(session, script, args=None):
+    if args is None:
+        args = []
+    body = {"script": script, "args": args}
+    return session.transport.send(
+        "POST",
+        "/session/{session_id}/execute/sync".format(
+            session_id=session.session_id),
+        body)
+
+
+def test_array(session):
+    response = execute_script(session, """
+        let arr = [];
+        arr.push(arr);
+        return arr;
+        """)
+    assert_error(response, "javascript error")
+
+
+def test_object(session):
+    response = execute_script(session, """
+        let obj = {};
+        obj.reference = obj;
+        return obj;
+        """)
+    assert_error(response, "javascript error")
+
+
+def test_array_in_object(session):
+    response = execute_script(session, """
+        let arr = [];
+        arr.push(arr);
+        return {arr};
+        """)
+    assert_error(response, "javascript error")
+
+
+def test_object_in_array(session):
+    response = execute_script(session, """
+        let obj = {};
+        obj.reference = obj;
+        return [obj];
+        """)
+    assert_error(response, "javascript error")


### PR DESCRIPTION
Marionette does currently not test for cyclic object references as
it marshals return values for transport across the wire.

Example of cyclic object:

	let obj = {};
	obj.cyclic = obj;

Passing this through evalaute.toJSON currently causes an infinite
recursion due to obj being referenced inside itself.  We can use
JSON.stringify to test if obj contains such cyclic values.  It is
assumed that the input to assert.acyclic is already JSON safe, so it can
be parsed by JSON.stringify, because of the previous checks it has made.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=Bug 1106913
gecko-commit: 04b16dc7a9b8a429049fdfef93436483c2ef662b
gecko-integration-branch: central
gecko-reviewers: whimboo