### PR TITLE
[Gecko Bug 1351409]  Remove animationiteration from legacy event listener test, make the transition tests more robust, and re-enable that test. r=jmaher

### DIFF
--- a/dom/events/EventListener-invoke-legacy.html
+++ b/dom/events/EventListener-invoke-legacy.html
@@ -51,22 +51,16 @@ function runLegacyEventTest(type, legacyType, ctor, setup) {
 }
 
 function setupTransition(elem) {
-  elem.style.transition = '';
-  requestAnimationFrame(function() {
-    elem.style.color = 'red';
-    elem.style.transition = 'color 30ms';
-    requestAnimationFrame(function() {
-      elem.style.color = 'green';
-    });
-  });
+  getComputedStyle(elem).color;
+  elem.style.color = 'green';
+  elem.style.transition = 'color 30ms';
 }
 
 function setupAnimation(elem) {
-  elem.style.animation = 'test 30ms 2';
+  elem.style.animation = 'test 30ms';
 }
 
 runLegacyEventTest('transitionend', 'webkitTransitionEnd', "TransitionEvent", setupTransition);
 runLegacyEventTest('animationend', 'webkitAnimationEnd', "AnimationEvent", setupAnimation);
-runLegacyEventTest('animationiteration', 'webkitAnimationIteration', "AnimationEvent", setupAnimation);
 runLegacyEventTest('animationstart', 'webkitAnimationStart', "AnimationEvent", setupAnimation);
 </script>


### PR DESCRIPTION
According to :birtles, it is not guaranteed that animationiteration
event will be fired. This event is sample-based rather than event-based,
and such behavior has been clarified in CSS Animations Level 2:
https://drafts.csswg.org/css-animations-2/#event-dispatch

Also, Chromium has the same issue with this test:
https://bugs.chromium.org/p/chromium/issues/detail?id=701445
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1351409
gecko-commit: fa855df2e888bb6edbed237d7a6b78ab6476c96b
gecko-integration-branch: central
gecko-reviewers: jmaher