### PR TITLE
[Gecko Bug 1426246] Bug 1426246: Fix inheritance of animation and transition properties of mismatched length. r=hiro

### DIFF
--- a/css/css-animations/animation-delay-011.html
+++ b/css/css-animations/animation-delay-011.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Animations Test: inherited animation-delay with mismatched animation-name length</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/css-animations-1/#animations">
+<link rel="match" href="animation-common-ref.html">
+<style>
+div:after {
+  content: '';
+  display: block;
+  width: 100px;
+  height: 100px;
+  background: red;
+  animation: doesntmatter 50s linear infinite,
+             bg 100s step-end infinite;
+  animation-play-state: paused;
+  animation-delay: inherit;
+}
+
+@keyframes bg {
+  50% { background: green; }
+}
+</style>
+<div style="animation-delay: -50s"></div>


### PR DESCRIPTION
At least when the animation-name length is bigger than the animation properties,
we mess up inheritance and only set properly the specified counts, then don't
cycle it.

The nicer fix for this is making these vectors properly, and move the cycling
logic at used-value time (bug 1420928). Same for transitions.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1426246
gecko-commit: 064e0be1cc29617de74098aba4b3bb706775315a
gecko-integration-branch: central
gecko-reviewers: hiro