### PR TITLE
[Gecko Bug 1429384]  Stop toggling selectedness state of <option disabled>. r=automatedtester

### DIFF
--- a/webdriver/tests/element_click/select.py
+++ b/webdriver/tests/element_click/select.py
@@ -211,3 +211,15 @@ def test_out_of_view_multiple(session):
     last_option = options[-1]
     last_option.click()
     assert last_option.selected
+
+
+def test_option_disabled(session):
+    session.url = inline("""
+        <select>
+          <option disabled>foo
+        </select>""")
+    option = session.find.css("option", all=False)
+    assert not option.selected
+
+    option.click()
+    assert not option.selected


### PR DESCRIPTION
When WebDriver:ElementClick clicks an <option disabled> element,
its selectedness state should according to a new specification
change proposed not change:

	https://github.com/w3c/webdriver/pull/1189

This patch provides tests for the specification change.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1429384
gecko-commit: be8ebea8beb1e445a3382b6b071401f78de6e622
gecko-integration-branch: central
gecko-reviewers: automatedtester