### PR TITLE
[Gecko Bug 1429388]  Use classic pytest output style for WPT. r=davehunt,jgraham

### DIFF
--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -58,6 +58,7 @@ def run(path, server_config, session_config, timeout=0):
                          "--showlocals",  # display contents of variables in local scope
                          "-p", "no:mozlog",  # use the WPT result recorder
                          "-p", "no:cacheprovider",  # disable state preservation across invocations
+                         "-o=console_output_style=classic",  # disable test progress bar
                          path],
                         plugins=[harness, subtests])
         except Exception as e:


### PR DESCRIPTION
The upstream upgrade of pytest came with a new test progress
percentage feature that introduced a lot of unnecessary log output
in WPT wdspec tests.

This adds a pytest flag that reverts it to use the "classic" output
style, which does not have a test progress bar.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1429388
gecko-commit: 4f065bc82a465371aaa8b6dc0de9514cf6e859c8
gecko-integration-branch: central
gecko-reviewers: davehunt, jgraham