### PR TITLE
[Gecko Bug 1426979] blank-replacement.https.html check simple about:blank and about:srcdoc cases. r=asuth

### DIFF
--- a/service-workers/service-worker/about-blank-replacement.https.html
+++ b/service-workers/service-worker/about-blank-replacement.https.html
@@ -58,7 +58,7 @@ function getClientIdByURL(worker, url) {
   });
 }
 
-async function doAsyncTest(t, scope, extraSearchParams) {
+async function doAsyncTest(t, scope) {
   let reg = await service_worker_unregister_and_register(t, worker, scope);
   await wait_for_state(t, reg.installing, 'activated');
 
@@ -70,20 +70,30 @@ async function doAsyncTest(t, scope, extraSearchParams) {
   let initialResult = frame.contentWindow.nested().document.body.textContent;
   assert_false(initialResult.startsWith('failure:'), `result: ${initialResult}`);
 
+  assert_equals(frame.contentWindow.navigator.serviceWorker.controller.scriptURL,
+                frame.contentWindow.nested().navigator.serviceWorker.controller.scriptURL,
+                'nested about:blank should have same controlling service worker');
+
   // Next, ask the service worker to find the final client ID for the fully
   // loaded nested frame.
-  let nestedURL = new URL(scope, window.location);
-  nestedURL.searchParams.set('nested', true);
-  extraSearchParams = extraSearchParams || {};
-  for (let p in extraSearchParams) {
-    nestedURL.searchParams.set(p, extraSearchParams[p]);
-  }
+  let nestedURL = new URL(frame.contentWindow.nested().location);
   let finalResult = await getClientIdByURL(reg.active, nestedURL);
   assert_false(finalResult.startsWith('failure:'), `result: ${finalResult}`);
 
-  // The initial about:blank client and the final loaded client should have
-  // the same ID value.
-  assert_equals(initialResult, finalResult, 'client ID values should match');
+  // If the nested frame doesn't have a URL to load, then there is no fetch
+  // event and the body should be empty.  We can't verify the final client ID
+  // against anything.
+  if (nestedURL.href === 'about:blank' ||
+      nestedURL.href === 'about:srcdoc') {
+    assert_equals('', initialResult, 'about:blank text content should be blank');
+  }
+
+  // If the nested URL is not about:blank, though, then the fetch event handler
+  // should have populated the body with the client id of the initial about:blank.
+  // Verify the final client id matches.
+  else {
+    assert_equals(initialResult, finalResult, 'client ID values should match');
+  }
 
   frame.remove();
   await service_worker_unregister_and_done(t, scope);
@@ -101,8 +111,7 @@ promise_test(async function(t) {
   // worker can ping the client to verify its existence.  This ping-pong
   // check is performed during the initial load and when verifying the
   // final loaded client.
-  await doAsyncTest(t, 'resources/about-blank-replacement-ping-frame.py',
-                    { 'ping': true });
+  await doAsyncTest(t, 'resources/about-blank-replacement-ping-frame.py');
 }, 'Initial about:blank modified by parent is controlled, exposed to ' +
    'clients.matchAll(), and matches final Client.');
 
@@ -141,6 +150,28 @@ promise_test(async function(t) {
   await service_worker_unregister_and_done(t, scope);
 }, 'Initial about:blank is controlled, exposed to clients.matchAll(), and ' +
    'final Client is not controlled by a service worker.');
+
+promise_test(async function(t) {
+  // Execute a test where the nested frame is an iframe without a src
+  // attribute.  This simple nested about:blank should still inherit the
+  // controller and be visible to clients.matchAll().
+  await doAsyncTest(t, 'resources/about-blank-replacement-blank-nested-frame.html');
+}, 'Simple about:blank is controlled and is exposed to clients.matchAll().');
+
+promise_test(async function(t) {
+  // Execute a test where the nested frame is an iframe using a non-empty
+  // srcdoc containing only a tag pair so its textContent is still empty.
+  // This nested iframe should still inherit the controller and be visible
+  // to clients.matchAll().
+  await doAsyncTest(t, 'resources/about-blank-replacement-srcdoc-nested-frame.html');
+}, 'Nested about:srcdoc is controlled and is exposed to clients.matchAll().');
+
+promise_test(async function(t) {
+  // Execute a test where the nested frame is dynamically added without a src
+  // attribute.  This simple nested about:blank should still inherit the
+  // controller and be visible to clients.matchAll().
+  await doAsyncTest(t, 'resources/about-blank-replacement-blank-dynamic-nested-frame.html');
+}, 'Dynamic about:blank is controlled and is exposed to clients.matchAll().');
 
 </script>
 </body>

--- a/service-workers/service-worker/resources/about-blank-replacement-blank-dynamic-nested-frame.html
+++ b/service-workers/service-worker/resources/about-blank-replacement-blank-dynamic-nested-frame.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<body>
+<script>
+function nestedLoaded() {
+  parent.postMessage({ type: 'NESTED_LOADED' }, '*');
+}
+
+// dynamically add an about:blank iframe
+var f = document.createElement('iframe');
+f.onload = nestedLoaded;
+document.body.appendChild(f);
+
+// Helper routine to make it slightly easier for our parent to find
+// the nested frame.
+function nested() {
+  return f.contentWindow;
+}
+</script>
+</body>
+</html>

--- a/service-workers/service-worker/resources/about-blank-replacement-blank-nested-frame.html
+++ b/service-workers/service-worker/resources/about-blank-replacement-blank-nested-frame.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<body>
+<script>
+function nestedLoaded() {
+  parent.postMessage({ type: 'NESTED_LOADED' }, '*');
+}
+</script>
+<iframe id="nested" onload="nestedLoaded()"></iframe>
+<script>
+// Helper routine to make it slightly easier for our parent to find
+// the nested frame.
+function nested() {
+  return document.getElementById('nested').contentWindow;
+}
+
+// NOTE: Make sure not to touch the iframe directly here.  We want to
+//       test the case where the initial about:blank document is not
+//       directly accessed before load.
+</script>
+</body>
+</html>

--- a/service-workers/service-worker/resources/about-blank-replacement-srcdoc-nested-frame.html
+++ b/service-workers/service-worker/resources/about-blank-replacement-srcdoc-nested-frame.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<body>
+<script>
+function nestedLoaded() {
+  parent.postMessage({ type: 'NESTED_LOADED' }, '*');
+}
+</script>
+<iframe id="nested" srcdoc="<div></div>" onload="nestedLoaded()"></iframe>
+<script>
+// Helper routine to make it slightly easier for our parent to find
+// the nested frame.
+function nested() {
+  return document.getElementById('nested').contentWindow;
+}
+
+// NOTE: Make sure not to touch the iframe directly here.  We want to
+//       test the case where the initial about:blank document is not
+//       directly accessed before load.
+</script>
+</body>
+</html>


### PR DESCRIPTION
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1426979
gecko-commit: a4c611046a0c977a82d0797af446a1b2fca2ee7a
gecko-integration-branch: central
gecko-reviewers: asuth