### PR TITLE
[Gecko Bug 1400716]  Explicitly drain all queues on exit, r=maja_zf

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -568,7 +568,7 @@ class InternalRefTestImplementation(object):
             self.executor.protocol.marionette.set_context(self.executor.protocol.marionette.CONTEXT_CONTENT)
         except Exception as e:
             # Ignore errors during teardown
-            self.logger.warning(traceback.traceback.format_exc(e))
+            self.logger.warning(traceback.format_exc(e))
 
 
 

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -175,7 +175,11 @@ class MarionetteProtocol(Protocol):
             # This can happen if there was a crash
             return
         if socket_timeout:
-            self.marionette.timeout.script = socket_timeout / 2
+            try:
+                self.marionette.timeout.script = socket_timeout / 2
+            except (socket.error, IOError):
+                self.logger.debug("Socket closed")
+                return
 
         self.marionette.switch_to_window(self.runner_handle)
         while True:

--- a/tools/wptrunner/wptrunner/wptlogging.py
+++ b/tools/wptrunner/wptrunner/wptlogging.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import threading
+from Queue import Empty
 from StringIO import StringIO
 from multiprocessing import Queue
 
@@ -43,7 +44,6 @@ class LogLevelRewriter(object):
             data = data.copy()
             data["level"] = self.to_level
         return self.inner(data)
-
 
 
 class LogThread(threading.Thread):
@@ -120,5 +120,10 @@ class CaptureIO(object):
                 self.logging_queue.put(None)
                 if self.logging_thread is not None:
                     self.logging_thread.join(10)
+                while not self.logging_queue.empty():
+                    try:
+                        self.logger.warning("Dropping log message: %r", self.logging_queue.get())
+                    except Exception:
+                        pass
                 self.logging_queue.close()
                 self.logger.info("queue closed")


### PR DESCRIPTION
The fact that the queues were not drained on exist seemed to cause an
intermittent failure where one process tried to write to a queue that
another had closed. Draining the queues explicitly should avoid this
and ensure we surface hidden problems in the log.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1400716
gecko-commit: 0ea252bf357c2ff56b9f0dcd6db6d094efc7a1e8
gecko-integration-branch: central
gecko-reviewers: maja_zf