### PR TITLE
[Gecko Bug 1428582]  Preprocess wpt lint paths to be relative to the wpt root r=jgraham

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -722,7 +722,8 @@ def changed_files(wpt_root):
 
 def lint_paths(kwargs, wpt_root):
     if kwargs.get("paths"):
-        paths = kwargs["paths"]
+        r = os.path.realpath(wpt_root)
+        paths = [os.path.relpath(os.path.realpath(x), r) for x in kwargs["paths"]]
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))
     else:


### PR DESCRIPTION
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1428582
gecko-commit: 03edb935ed6841a7fd43dfbc4b5cb0b939d5b8aa
gecko-integration-branch: central
gecko-reviewers: jgraham