### PR TITLE
[Gecko Bug 1429562]  Remove obsolete optional parameter `reset_session_id` from `delete_session`. r=ato

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -96,7 +96,7 @@ class MarionetteProtocol(Protocol):
     def teardown(self):
         try:
             self.marionette._request_in_app_shutdown()
-            self.marionette.delete_session(send_request=False, reset_session_id=True)
+            self.marionette.delete_session(send_request=False)
         except Exception:
             # This is typically because the session never started
             pass


### PR DESCRIPTION
By calling "delete_session" the currently used session id always has to be reset,
because each session has its own unique id.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1429562
gecko-commit: ec1a634f8feaa198469acf34f37d13e917175226
gecko-integration-branch: autoland
gecko-reviewers: ato