### PR TITLE
[Gecko Bug 1303025]  Accept null for body param in constructor of Response. r=bkelly

### DIFF
--- a/fetch/api/response/response-init-002.html
+++ b/fetch/api/response/response-init-002.html
@@ -65,6 +65,11 @@
         });
       }, "Testing empty Response Content-Type header");
 
+      test(function() {
+        var response = new Response(null, {status: 204});
+        assert_equals(response.body, null);
+      }, "Testing null Response body");
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1303025
gecko-commit: 62f5c4a3682381134b607d359824b7605ec15156
gecko-integration-branch: autoland
gecko-reviewers: bkelly