### PR TITLE
[Gecko Bug 1403923]  Safely shutdown Firefox from in delete_session. r=jgraham

### DIFF
--- a/webdriver/tests/state/get_element_attribute.py
+++ b/webdriver/tests/state/get_element_attribute.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 import pytest
 
 from tests.support.asserts import assert_error, assert_success, assert_dialog_handled

--- a/webdriver/tests/state/get_element_property.py
+++ b/webdriver/tests/state/get_element_property.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
 from tests.support.inline import inline
 from tests.support.fixtures import create_dialog

--- a/webdriver/tests/state/get_element_tag_name.py
+++ b/webdriver/tests/state/get_element_tag_name.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
 from tests.support.inline import inline
 from tests.support.fixtures import create_dialog

--- a/webdriver/tests/state/is_element_selected.py
+++ b/webdriver/tests/state/is_element_selected.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
 from tests.support.inline import inline
 from tests.support.fixtures import create_dialog


### PR DESCRIPTION
With the request to shutdown the browser, a given amount of time
has to be waited to allow the process to shutdown itself. Only
if the process is still running afterward it has to be killed.

Firefox has an integrated background monitor which observes
long running threads during shutdown, and kills those after
65s. To allow Firefox to shutdown on its own, geckodriver
has to wait that time, and some additional seconds.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1403923
gecko-commit: 025d4690bfbe602a82d91f827a67208df80dc110
gecko-integration-branch: central
gecko-reviewers: jgraham