### PR TITLE
[Gecko Bug 1430947]  Add [SecureContext] to navigator.credentials r=bz

### DIFF
--- a/credential-management/require_securecontext.html
+++ b/credential-management/require_securecontext.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that Credential Management requires secure contexts</title>
+<link rel="help" href="https://w3c.github.io/webappsec-credential-management/#idl-index">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+"use strict";
+  test(() => {
+    assert_false(isSecureContext);
+    assert_false('credentials' in navigator);
+  }, "Credential Management must not be accessible in insecure contexts");
+</script>


### PR DESCRIPTION
It was neglected to mark navigator.credentials as [SecureContext], yet it
must be for spec compliance and powerful-features compliance.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1430947
gecko-commit: 9f192d955648318fb10df4960cdbe2bcb1181c89
gecko-integration-branch: central
gecko-reviewers: bz