### PR TITLE
[Gecko Bug 1430654]  Introduce assert_time_equals_literal and use it. r=birtles

### DIFF
--- a/web-animations/README.md
+++ b/web-animations/README.md
@@ -98,10 +98,19 @@ Guidelines for writing tests
     Remember, even if we do need to make all tests take, say 200s each, text
     editors are very good at search and replace.
 
-*   Use the `assert_times_equal` assertion for comparing calculated times.
-    It tests times are equal using the precision recommended in the spec whilst
-    allowing implementations to override the function to meet their own
-    precision requirements.
+*   Use the `assert_times_equal` assertion for comparing times returned from
+    the API. This asserts that the time values are equal using a tolerance
+    based on the precision recommended in the spec. This tolerance is applied
+    to *both* of the values being compared. That is, it effectively allows
+    double the epsilon that is used when comparing with an absolute value.
+
+    For comparing a time value returned from the API to an absolute value, use
+    `assert_time_equals_literal`. This tests that the actual value is equal to
+    the expected value within the precision recommended in the spec.
+
+    Both `assert_times_equal` and `assert_time_equals_literal` are defined in a
+    way that implementations can override them to meet their own precision
+    requirements.
 
 *   There are quite a few bad tests in the repository. We're learning as
     we go. Don't just copy them blindly&mdash;please fix them!

--- a/web-animations/interfaces/Animation/playbackRate.html
+++ b/web-animations/interfaces/Animation/playbackRate.html
@@ -14,16 +14,14 @@ function assert_playbackrate(animation,
                              previousAnimationCurrentTime,
                              previousTimelineCurrentTime,
                              description) {
-  const accuracy = 0.001; /* accuracy of DOMHighResTimeStamp */
   const animationCurrentTimeDifference =
     animation.currentTime - previousAnimationCurrentTime;
   const timelineCurrentTimeDifference =
     animation.timeline.currentTime - previousTimelineCurrentTime;
 
-  assert_approx_equals(animationCurrentTimeDifference,
-                       timelineCurrentTimeDifference * animation.playbackRate,
-                       accuracy,
-                       description);
+  assert_times_equal(animationCurrentTimeDifference,
+                     timelineCurrentTimeDifference * animation.playbackRate,
+                     description);
 }
 
 promise_test(t => {

--- a/web-animations/interfaces/AnimationEffectTiming/direction.html
+++ b/web-animations/interfaces/AnimationEffectTiming/direction.html
@@ -31,13 +31,13 @@ test(t => {
   const div = createDiv(t);
   const anim = div.animate(null, { duration: 10000, direction: 'normal' });
   anim.currentTime = 7000;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.7,
-                     'progress before updating direction');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.7,
+                             'progress before updating direction');
 
   anim.effect.timing.direction = 'reverse';
 
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.3,
-                     'progress after updating direction');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.3,
+                             'progress after updating direction');
 }, 'Can be changed from \'normal\' to \'reverse\' while in progress');
 
 test(t => {
@@ -78,13 +78,13 @@ test(t => {
                              duration: 10000,
                              direction: 'normal' });
   anim.currentTime = 17000;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.7,
-                     'progress before updating direction');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.7,
+                             'progress before updating direction');
 
   anim.effect.timing.direction = 'alternate';
 
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.3,
-                     'progress after updating direction');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.3,
+                             'progress after updating direction');
 }, 'Can be changed from \'normal\' to \'alternate\' while in progress');
 
 test(t => {
@@ -94,13 +94,13 @@ test(t => {
                              duration: 10000,
                              direction: 'alternate' });
   anim.currentTime = 17000;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.3,
-                     'progress before updating direction');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.3,
+                             'progress before updating direction');
 
   anim.effect.timing.direction = 'alternate-reverse';
 
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.7,
-                     'progress after updating direction');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.7,
+                             'progress after updating direction');
 }, 'Can be changed from \'alternate\' to \'alternate-reverse\' while in'
    + ' progress');
 

--- a/web-animations/interfaces/AnimationEffectTiming/duration.html
+++ b/web-animations/interfaces/AnimationEffectTiming/duration.html
@@ -19,10 +19,10 @@ test(t => {
   const div = createDiv(t);
   const anim = div.animate({ opacity: [ 0, 1 ] }, 2000);
   anim.effect.timing.duration = 123.45;
-  assert_times_equal(anim.effect.timing.duration, 123.45,
-                     'set duration 123.45');
-  assert_times_equal(anim.effect.getComputedTiming().duration, 123.45,
-                     'getComputedTiming() after set duration 123.45');
+  assert_time_equals_literal(anim.effect.timing.duration, 123.45,
+                             'set duration 123.45');
+  assert_time_equals_literal(anim.effect.getComputedTiming().duration, 123.45,
+                             'getComputedTiming() after set duration 123.45');
 }, 'Can be set to a double value');
 
 test(t => {
@@ -176,8 +176,8 @@ test(t => {
   assert_equals(anim.effect.getComputedTiming().progress, 1,
                 'progress when animation is finished');
   anim.effect.timing.duration *= 2;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5,
-                     'progress after doubling the duration');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5,
+                             'progress after doubling the duration');
   anim.effect.timing.duration = 0;
   assert_equals(anim.effect.getComputedTiming().progress, 1,
                 'progress after setting duration to zero');

--- a/web-animations/interfaces/AnimationEffectTiming/endDelay.html
+++ b/web-animations/interfaces/AnimationEffectTiming/endDelay.html
@@ -19,10 +19,10 @@ test(t => {
   const div = createDiv(t);
   const anim = div.animate({ opacity: [ 0, 1 ] }, 2000);
   anim.effect.timing.endDelay = 123.45;
-  assert_times_equal(anim.effect.timing.endDelay, 123.45,
-                     'set endDelay 123.45');
-  assert_times_equal(anim.effect.getComputedTiming().endDelay, 123.45,
-                     'getComputedTiming() after set endDelay 123.45');
+  assert_time_equals_literal(anim.effect.timing.endDelay, 123.45,
+                             'set endDelay 123.45');
+  assert_time_equals_literal(anim.effect.getComputedTiming().endDelay, 123.45,
+                             'getComputedTiming() after set endDelay 123.45');
 }, 'Can be set to a positive number');
 
 test(t => {

--- a/web-animations/interfaces/AnimationEffectTiming/iterationStart.html
+++ b/web-animations/interfaces/AnimationEffectTiming/iterationStart.html
@@ -24,7 +24,7 @@ test(t => {
                              duration: 100,
                              delay: 1 });
   anim.effect.timing.iterationStart = 2.5;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
 }, 'Changing the value updates computed timing when backwards-filling');
 
@@ -37,7 +37,7 @@ test(t => {
                              duration: 100,
                              delay: 0 });
   anim.effect.timing.iterationStart = 2.5;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
 }, 'Changing the value updates computed timing during the active phase');
 
@@ -51,7 +51,7 @@ test(t => {
                              delay: 0 });
   anim.finish();
   anim.effect.timing.iterationStart = 2.5;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 3);
 }, 'Changing the value updates computed timing when forwards-filling');
 

--- a/web-animations/interfaces/AnimationEffectTiming/iterations.html
+++ b/web-animations/interfaces/AnimationEffectTiming/iterations.html
@@ -70,10 +70,12 @@ test(t => {
 
   anim.effect.timing.iterations = 2;
 
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0,
-                     'progress after adding an iteration');
-  assert_times_equal(anim.effect.getComputedTiming().currentIteration, 1,
-                     'current iteration after adding an iteration');
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress,
+                             0,
+                             'progress after adding an iteration');
+  assert_time_equals_literal(anim.effect.getComputedTiming().currentIteration,
+                             1,
+                             'current iteration after adding an iteration');
 
   anim.effect.timing.iterations = 0;
 

--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -25,6 +25,14 @@ if (!window.assert_times_equal) {
   };
 }
 
+// Allow implementations to substitute an alternative method for comparing
+// a time value based on its precision requirements with a fixed value.
+if (!window.assert_time_equals_literal) {
+  window.assert_time_equals_literal = (actual, expected, description) => {
+    assert_approx_equals(actual, expected, TIME_PRECISION, description);
+  }
+}
+
 // creates div element, appends it to the document body and
 // removes the created element during test cleanup
 function createDiv(test, doc) {

--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -21,7 +21,7 @@ const TIME_PRECISION = 0.0005; // ms
 // times based on their precision requirements.
 if (!window.assert_times_equal) {
   window.assert_times_equal = (actual, expected, description) => {
-    assert_approx_equals(actual, expected, TIME_PRECISION, description);
+    assert_approx_equals(actual, expected, TIME_PRECISION * 2, description);
   };
 }
 

--- a/web-animations/timing-model/animation-effects/active-time.html
+++ b/web-animations/timing-model/animation-effects/active-time.html
@@ -25,19 +25,19 @@ test(t => {
 test(t => {
   const anim = createDiv(t).animate(null, 1000);
   anim.currentTime = 500;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
 }, 'Active time in active phase and no start delay is the local time');
 
 test(t => {
   const anim = createDiv(t).animate(null, { duration: 1000, delay: 500 });
   anim.currentTime = 1000;
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
 }, 'Active time in active phase and positive start delay is the local time'
    + ' minus the start delay');
 
 test(t => {
   const anim = createDiv(t).animate(null, { duration: 1000, delay: -500 });
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
 }, 'Active time in active phase and negative start delay is the local time'
    + ' minus the start delay');
 
@@ -58,7 +58,7 @@ test(t => {
                                             fill: 'forwards' });
   anim.finish();
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.3);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.3);
 }, 'Active time in after phase with forwards fill is the active duration');
 
 test(t => {
@@ -79,7 +79,7 @@ test(t => {
                                             fill: 'forwards' });
   anim.finish();
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.3);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.3);
 }, 'Active time in after phase with forwards fill and positive end delay'
    + ' is the active duration');
 
@@ -91,7 +91,7 @@ test(t => {
                                             fill: 'forwards' });
   anim.finish();
   assert_equals(anim.effect.getComputedTiming().currentIteration, 1);
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.5);
 }, 'Active time in after phase with forwards fill and negative end delay'
    + ' is the active duration + end delay');
 
@@ -127,7 +127,7 @@ test(t => {
                                             fill: 'both' });
   anim.finish();
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
-  assert_times_equal(anim.effect.getComputedTiming().progress, 0.3);
+  assert_time_equals_literal(anim.effect.getComputedTiming().progress, 0.3);
 }, 'Active time in after phase with \'both\' fill is the active duration');
 
 test(t => {

--- a/web-animations/timing-model/animations/current-time.html
+++ b/web-animations/timing-model/animations/current-time.html
@@ -68,7 +68,7 @@ promise_test(t => {
 
   return animation.ready.then(() => waitForAnimationFrames(1))
   .then(() => {
-    assert_times_equal(animation.currentTime, 0);
+    assert_time_equals_literal(animation.currentTime, 0);
   });
 }, 'The current time does not progress if playback rate is 0');
 

--- a/web-animations/timing-model/animations/playing-an-animation.html
+++ b/web-animations/timing-model/animations/playing-an-animation.html
@@ -14,26 +14,26 @@
 test(t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
   animation.currentTime = 1 * MS_PER_SEC;
-  assert_times_equal(animation.currentTime, 1 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 1 * MS_PER_SEC);
   animation.play();
-  assert_times_equal(animation.currentTime, 1 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 1 * MS_PER_SEC);
 }, 'Playing a running animation leaves the current time unchanged');
 
 test(t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
   animation.finish();
-  assert_times_equal(animation.currentTime, 100 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 100 * MS_PER_SEC);
   animation.play();
-  assert_times_equal(animation.currentTime, 0);
+  assert_time_equals_literal(animation.currentTime, 0);
 }, 'Playing a finished animation seeks back to the start');
 
 test(t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
   animation.playbackRate = -1;
   animation.currentTime = 0;
-  assert_times_equal(animation.currentTime, 0);
+  assert_time_equals_literal(animation.currentTime, 0);
   animation.play();
-  assert_times_equal(animation.currentTime, 100 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 100 * MS_PER_SEC);
 }, 'Playing a finished and reversed animation seeks to end');
 
 test(t => {

--- a/web-animations/timing-model/animations/set-the-animation-start-time.html
+++ b/web-animations/timing-model/animations/set-the-animation-start-time.html
@@ -80,9 +80,9 @@ test(t => {
 
   // If we set the start time, however, we should clear the hold time.
   animation.startTime = document.timeline.currentTime - 2000;
-  assert_times_equal(animation.currentTime, 2000,
-                     'The current time is calculated from the start time,'
-                     + ' not the hold time');
+  assert_time_equals_literal(animation.currentTime, 2000,
+                             'The current time is calculated from the start'
+                             + ' time, not the hold time');
 
   // Sanity check
   assert_equals(animation.playState, 'running',
@@ -99,13 +99,14 @@ test(t => {
   // are resolved).
   animation.startTime = document.timeline.currentTime - 1000;
   assert_equals(animation.playState, 'running');
-  assert_times_equal(animation.currentTime, 1000,
-                     'Current time is resolved for a running animation')
+  assert_time_equals_literal(animation.currentTime, 1000,
+                             'Current time is resolved for a running animation');
 
   // Clear start time
   animation.startTime = null;
-  assert_times_equal(animation.currentTime, 1000,
-                     'Hold time is set after start time is made unresolved');
+  assert_time_equals_literal(animation.currentTime, 1000,
+                             'Hold time is set after start time is made'
+                             + ' unresolved');
   assert_equals(animation.playState, 'paused',
                 'Animation reports it is paused after setting an unresolved'
                 + ' start time');

--- a/web-animations/timing-model/animations/set-the-timeline-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-timeline-of-an-animation.html
@@ -26,7 +26,7 @@ test(t => {
   animation.timeline = document.timeline;
 
   assert_equals(animation.playState, 'paused');
-  assert_times_equal(animation.currentTime, 50 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 50 * MS_PER_SEC);
 }, 'After setting timeline on paused animation it is still paused');
 
 test(t => {
@@ -39,7 +39,7 @@ test(t => {
   animation.timeline = document.timeline;
 
   assert_equals(animation.playState, 'paused');
-  assert_times_equal(animation.currentTime, 200 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 200 * MS_PER_SEC);
 }, 'After setting timeline on animation paused outside active interval'
    + ' it is still paused');
 
@@ -141,7 +141,7 @@ test(t => {
 
   assert_false(animation.pending);
   assert_equals(animation.playState, 'paused');
-  assert_times_equal(animation.currentTime, 50 * MS_PER_SEC);
+  assert_time_equals_literal(animation.currentTime, 50 * MS_PER_SEC);
 }, 'After clearing timeline on paused animation it is still paused');
 
 test(t => {


### PR DESCRIPTION
This assertion is supposed to be used where the first argument has a tolerance
but the second argument doesn't have such tolerance.  Whereas
assert_times_equal() is supposed to be used for the case both arguments have
the same tolerance, actually it hasn't, it will be fixed in a subsequent patch
in this patch series.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1430654
gecko-commit: edbac2302f907df4fca6aea3843bd033a1a1bb89
gecko-integration-branch: central
gecko-reviewers: birtles