### PR TITLE
[Gecko Bug 1433417] Fix a bunch of typo in the doc

### DIFF
--- a/tools/wptrunner/README.rst
+++ b/tools/wptrunner/README.rst
@@ -197,7 +197,7 @@ language e.g.::
 
   if debug and (platform == "linux" or platform == "osx"): FAIL
 
-For test expectations the avaliable variables are those in the
+For test expectations the available variables are those in the
 `run_info` which for desktop are `version`, `os`, `bits`, `processor`,
 `debug` and `product`.
 


### PR DESCRIPTION
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1433417
gecko-commit: 4f1a5068af92d329781d4805519a0904c45d0e67
gecko-integration-branch: central
gecko-reviewers: ahal