### PR TITLE
[Gecko Bug 958714] part 1: Remove special case for flex & grid items' percent block-axis margin/padding resolution, to align with other browsers.

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-mbp-horiz-004-ref.xhtml
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-mbp-horiz-004-ref.xhtml
@@ -4,8 +4,7 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <!-- Reference case - identical to the testcase, but with with the flex items'
-     vertical margin and padding values set to 0 by default, and then set to
-     specific pixel values for the items that have a 50px percent-basis.
+     margin and padding values set to explicit pixel values.
 -->
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
@@ -21,27 +20,11 @@
       }
       div.height50 { height: 50px; }
 
-      .marginA  { margin:  0  8% 0  4%; }
-      .marginB  { margin:  0 10% 0 14%; }
-      .paddingA { padding: 0  6% 0  2%; }
-      .paddingB { padding: 0  8% 0 12%; }
+      .marginA  { margin:  20px 16px 12px  8px; }
+      .marginB  { margin:  16px 20px 24px 28px; }
+      .paddingA { padding: 16px 12px  8px  4px; }
+      .paddingB { padding: 12px 16px 20px 24px; }
 
-      div.height50 > .marginA {
-        margin-top: 5px;
-        margin-bottom: 3px;
-      }
-      div.height50 > .marginB {
-        margin-top: 4px;
-        margin-bottom: 6px;
-      }
-      div.height50 > .paddingA {
-        padding-top: 4px;
-        padding-bottom: 2px;
-      }
-      div.height50 > .paddingB {
-        padding-top: 3px;
-        padding-bottom: 5px;
-      }
 
       div.child1 {
         flex: none;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-mbp-horiz-004.xhtml
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-mbp-horiz-004.xhtml
@@ -3,19 +3,17 @@
      Any copyright is dedicated to the Public Domain.
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
-<!-- Testcase with percent-valued padding and/or margin on flex items. The spec
-     says that percentage values on padding/margin-top and -bottom should be
-     resolved against the flex container's height (not its width, as would
-     be the case in a block).
+<!-- Testcase with percent-valued padding and/or margin on flex items.
+     The spec allows these to be resolved against the flex container's
+     inline size (regardless of which axis the percent padding/margin is in).
 -->
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>CSS Test: Testing percent-valued padding and margin on flex items</title>
     <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com"/>
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#layout-algorithm"/>
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#item-margins"/>
     <link rel="match" href="flexbox-mbp-horiz-004-ref.xhtml"/>
     <style>
-      div { border: 0; }
       div.flexbox {
         width: 200px;
         display: flex;
@@ -52,8 +50,9 @@
     </style>
   </head>
   <body>
-    <!-- Flex container is auto-height - vertical margin and padding should
-         resolve to 0, since they don't have anything to resolve % against. -->
+    <!-- Flex container is auto-height - this shouldn't impact percent
+         margin/padding resolution, since they resolve against container's
+         inline-size, i.e. its width in this case. -->
     <div class="flexbox"
          ><div class="child1 paddingA"><div class="filler"/></div
          ><div class="child2 paddingB"><div class="filler"/></div
@@ -61,8 +60,9 @@
          ><div class="child2 marginB"></div
     ></div>
 
-    <!-- Flex container has height: 50px - vertical margin and padding should
-         resolve % values against that. -->
+    <!-- Flex container has height: 50px - again, this shouldn't impact percent
+         margin/padding resolution, since they resolve against container's
+         inline-size, i.e. its width in this case. -->
     <div class="flexbox height50"
          ><div class="child1 paddingA"><div class="filler"/></div
          ><div class="child2 paddingB"><div class="filler"/></div


### PR DESCRIPTION
Now, flex and grid items will resolve percent margin and padding against their
container's *inline-size*, even if the percent margin/padding is in the block
axis. This matches the CSS2 behavior that's always existed in block containers.
bugzilla-url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=958714
gecko-commit: 10163f95e43cb49673ea466cd729b75fdacb77a5
gecko-integration-branch: autoland
gecko-reviewers: mats